### PR TITLE
gncs-29: add x86-64 images

### DIFF
--- a/.github/workflows/merge-native-bs.yml
+++ b/.github/workflows/merge-native-bs.yml
@@ -12,7 +12,7 @@ on:
       - Makefile
 
 jobs:
-  build-push:
+  build-push-aarch64:
     if: github.event.pull_request.merged == true
     runs-on: [self-hosted, neoverse-n1]
     steps:
@@ -28,6 +28,28 @@ jobs:
 
           # Push images
           make push-native-aarch64-bs
+  build-push-x86-64:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker Image
+        run: |
+
+          # Build the images
+          make worker-native-x86_64-bs
+
+          # Login for images push
+          echo ${{ secrets.DANGER_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+          # Push images
+          make push-native-x86_64-bs
+  clean-dangling:
+    if: asdasds
+    runs-on: [self-hosted, neoverse-n1]
+    steps:
+      - name: Clean Dangling images
+        run: |
 
           # Delete all dangling packages org-wide, this is because this repo has epoch worker!
           gi-gh-container-cleaner --organization=${{ github.repository_owner }} --pat=${{ secrets.DANGER_TOKEN }}

--- a/.github/workflows/pr-native-bs.yml
+++ b/.github/workflows/pr-native-bs.yml
@@ -10,9 +10,15 @@ on:
       - Makefile
 
 jobs:
-  build:
+  build-aarch64:
     runs-on: [self-hosted, neoverse-n1]
     steps:
       - uses: actions/checkout@v3
       - name: Test Build Docker Image
         run: make worker-native-aarch64-bs
+  build-x86-64:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test Build Docker Image
+        run: make worker-native-x86_64-bs

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,34 @@
-MAKEFLAGS	+=	--silent --jobs 1
-ARM_CPUS	:=	cortex-a55 cortex-a76 neoverse-n1
-TAG_PREFIX	:=	ghcr.io/goro-network
-CPU_FEATS	:=	"-C target-feature=+neon,+aes,+sha2,+fp16"
-VER_WORKERS	:=	"2.302.1"
-BS_IMAGES	:=	$(addprefix native-aarch64-bs-,$(ARM_CPUS))
-BS_WORKERS	:=	$(addprefix worker-native-aarch64-bs-,$(ARM_CPUS))
-BS_REGISTRY	:=	$(addprefix push-native-aarch64-bs-,$(ARM_CPUS))
-RS_NIGHTLY	:=	"nightly-2023-02-10"
-RS_STABLE	:=	"1.68.0"
+MAKEFLAGS		+=	--silent --jobs 1
+TAG_PREFIX		:=	ghcr.io/goro-network
+VER_WORKERS		:=	"2.303.0"
+RS_NIGHTLY		:=	"nightly-2023-02-10"
+RS_STABLE		:=	"1.68.2"
+ARM_CPUS		:=	cortex-a55 cortex-a76 neoverse-n1
+ARM_FEATS		:=	"-C target-feature=+neon,+aes,+sha2,+fp16"
+ARM_IMAGES		:=	$(addprefix native-aarch64-bs-,$(ARM_CPUS))
+ARM_WORKERS		:=	$(addprefix worker-native-aarch64-bs-,$(ARM_CPUS))
+ARM_REGISTRY	:=	$(addprefix push-native-aarch64-bs-,$(ARM_CPUS))
+INTEL_CPUS		:=	x86-64 sapphirerapids skylake-avx512
+INTEL_IMAGES	:=	$(addprefix native-x86_64-bs-,$(INTEL_CPUS))
+INTEL_WORKERS	:=	$(addprefix worker-native-x86_64-bs-,$(INTEL_CPUS))
+INTEL_REGISTRY	:=	$(addprefix push-native-x86_64-bs-,$(INTEL_CPUS))
 
-.PHONY: all native-aarch64-bs ${BS_IMAGES} ${BS_WORKER} ${BS_REGISTRY}
-.ONESHELL: all native-aarch64-bs ${BS_IMAGES} ${BS_WORKER} ${BS_REGISTRY}
+.PHONY: native-aarch64-bs ${ARM_IMAGES} ${ARM_WORKERS} ${ARM_REGISTRY} ${INTEL_IMAGES} ${INTEL_WORKERS} ${INTEL_REGISTRY}
+.ONESHELL: native-aarch64-bs ${ARM_IMAGES} ${ARM_WORKERS} ${ARM_REGISTRY} ${INTEL_IMAGES} ${INTEL_WORKERS} ${INTEL_REGISTRY}
 
-all: | ${BS_WORKERS}
+native-aarch64-bs: | ${ARM_IMAGES}
 
-native-aarch64-bs: | ${BS_IMAGES}
+worker-native-aarch64-bs: | ${ARM_WORKERS}
 
-worker-native-aarch64-bs: | ${BS_WORKERS}
+push-native-aarch64-bs: | ${ARM_REGISTRY}
 
-push-native-aarch64-bs: | ${BS_REGISTRY}
+native-x86_64-bs: | ${INTEL_IMAGES}
 
-$(BS_IMAGES):
+worker-native-x86_64-bs: | ${INTEL_WORKERS}
+
+push-native-x86_64-bs: | ${INTEL_REGISTRY}
+
+$(ARM_IMAGES):
 	export CURRENT_CPU="$(strip $(subst native-aarch64-bs-,,$@))"
 	export IMAGE_PREFIX="${TAG_PREFIX}/native-aarch64-$${CURRENT_CPU}"
 	export BS_TAG="$${IMAGE_PREFIX}:builder-substrate"
@@ -30,12 +38,12 @@ $(BS_IMAGES):
 		-f native/builder-substrate.Dockerfile \
 		--build-arg CPU_ARCH="aarch64" \
 		--build-arg CPU_NAME=$${CURRENT_CPU} \
-		--build-arg RUSTFLAGS_FEATURES=${CPU_FEATS} \
+		--build-arg RUSTFLAGS_FEATURES=${ARM_FEATS} \
 		--build-arg RUST_VERSION_NIGHTLY=${RS_NIGHTLY} \
 		--build-arg RUST_VERSION_STABLE=${RS_STABLE} \
 		native/
 
-$(BS_WORKERS): | ${BS_IMAGES}
+$(ARM_WORKERS): | ${ARM_IMAGES}
 	export CURRENT_CPU="$(strip $(subst worker-native-aarch64-bs-,,$@))"
 	export IMAGE_PREFIX="${TAG_PREFIX}/native-aarch64-$${CURRENT_CPU}"
 	export BS_TAG="$${IMAGE_PREFIX}:builder-substrate"
@@ -51,9 +59,49 @@ $(BS_WORKERS): | ${BS_IMAGES}
 		--build-arg RUNNER_VER=${VER_WORKERS} \
 		native/
 
-$(BS_REGISTRY): | $(BS_WORKERS)
+$(ARM_REGISTRY): | $(ARM_WORKERS)
 	export CURRENT_CPU=$(strip $(subst push-native-aarch64-bs-,,$@))
 	export IMAGE_PREFIX="${TAG_PREFIX}/native-aarch64-$${CURRENT_CPU}"
+	export BS_TAG="$${IMAGE_PREFIX}:builder-substrate"
+	export CI_TAG="$${IMAGE_PREFIX}:ci-builder-substrate"
+	echo "\033[92mPushing Docker Image - Substrate Builder for $${CURRENT_CPU}\033[0m"
+	docker push $${BS_TAG}
+	docker push $${CI_TAG}
+
+$(INTEL_IMAGES):
+	export CURRENT_CPU="$(strip $(subst native-x86_64-bs-,,$@))"
+	export IMAGE_PREFIX="${TAG_PREFIX}/native-x86_64-$${CURRENT_CPU}"
+	export BS_TAG="$${IMAGE_PREFIX}:builder-substrate"
+	echo "\033[92mBuilding Docker Image - Substrate Builder for $${CURRENT_CPU}\033[0m"
+	docker build \
+		-t $${BS_TAG} \
+		-f native/builder-substrate.Dockerfile \
+		--build-arg CPU_ARCH="x86_64" \
+		--build-arg CPU_NAME=$${CURRENT_CPU} \
+		--build-arg RUSTFLAGS_FEATURES=${INTEL_FEATS} \
+		--build-arg RUST_VERSION_NIGHTLY=${RS_NIGHTLY} \
+		--build-arg RUST_VERSION_STABLE=${RS_STABLE} \
+		native/
+
+$(INTEL_WORKERS): | ${INTEL_IMAGES}
+	export CURRENT_CPU="$(strip $(subst worker-native-x86_64-bs-,,$@))"
+	export IMAGE_PREFIX="${TAG_PREFIX}/native-x86_64-$${CURRENT_CPU}"
+	export BS_TAG="$${IMAGE_PREFIX}:builder-substrate"
+	export CI_TAG="$${IMAGE_PREFIX}:ci-builder-substrate"
+	echo "\033[92mBuilding Docker Image - CI Substrate Builder for $${CURRENT_CPU}\033[0m"
+	docker build \
+		-t $${CI_TAG} \
+		-f native/builder-substrate-gh.Dockerfile \
+		--build-arg BASE_IMAGE_NAME=$${BS_TAG} \
+		--build-arg CPU_ARCH_ALT="x64" \
+		--build-arg CPU_ARCH="x86_64" \
+		--build-arg CPU_NAME=$${CURRENT_CPU} \
+		--build-arg RUNNER_VER=${VER_WORKERS} \
+		native/
+
+$(INTEL_REGISTRY): | $(INTEL_WORKERS)
+	export CURRENT_CPU=$(strip $(subst push-native-x86_64-bs-,,$@))
+	export IMAGE_PREFIX="${TAG_PREFIX}/native-x86_64-$${CURRENT_CPU}"
 	export BS_TAG="$${IMAGE_PREFIX}:builder-substrate"
 	export CI_TAG="$${IMAGE_PREFIX}:ci-builder-substrate"
 	echo "\033[92mPushing Docker Image - Substrate Builder for $${CURRENT_CPU}\033[0m"

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ TAG_PREFIX		:=	ghcr.io/goro-network
 VER_WORKERS		:=	"2.303.0"
 RS_NIGHTLY		:=	"nightly-2023-02-10"
 RS_STABLE		:=	"1.68.2"
-ARM_CPUS		:=	cortex-a55 cortex-a76 neoverse-n1
+ARM_CPUS		:=	cortex-a55
 ARM_FEATS		:=	"-C target-feature=+neon,+aes,+sha2,+fp16"
 ARM_IMAGES		:=	$(addprefix native-aarch64-bs-,$(ARM_CPUS))
 ARM_WORKERS		:=	$(addprefix worker-native-aarch64-bs-,$(ARM_CPUS))
 ARM_REGISTRY	:=	$(addprefix push-native-aarch64-bs-,$(ARM_CPUS))
-INTEL_CPUS		:=	x86-64 sapphirerapids skylake-avx512
+INTEL_CPUS		:=	x86-64
 INTEL_IMAGES	:=	$(addprefix native-x86_64-bs-,$(INTEL_CPUS))
 INTEL_WORKERS	:=	$(addprefix worker-native-x86_64-bs-,$(INTEL_CPUS))
 INTEL_REGISTRY	:=	$(addprefix push-native-x86_64-bs-,$(INTEL_CPUS))

--- a/native/builder-substrate.Dockerfile
+++ b/native/builder-substrate.Dockerfile
@@ -171,7 +171,6 @@ RUN cargo install --locked \
     cargo-nextest \
     cargo-spellcheck \
     cargo-udeps \
-    cargo-web \
     dylint-link \
     wasm-gc \
     wasm-pack && \


### PR DESCRIPTION
also:
- bumps stable `rust` to `1.68.2`
- uses github's worker for `x86-64` (`ubuntu-22.04`)
- uses a generic cpu for `x86-64`
- uses `cortex-a55` for `aarch64`
- bumps `gh runner` to `2.303.0`
- removes outdated `cargo-web`